### PR TITLE
Fix title chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Q: **How does swege determine the title of my webpage?**
 
    `title: This will serve as the title`
 
-   The example site uses both methods.
+   The example site uses both methods. Leave the first line empty to remove the
+   title.
 
 # LICENSE
 

--- a/swege.c
+++ b/swege.c
@@ -298,7 +298,6 @@ char *
 get_title(FILE * in)
 {
 	char *line = NULL;
-	int n_hashes;
 	size_t linecap = 0;
 	getline(&line, &linecap, in);
 
@@ -322,11 +321,8 @@ get_title(FILE * in)
 			}
 		}
 	} else if (strlen(line) >= 3 && line[0] == '#') {
-		/* Count the amount of '#' characters. */
-		for (n_hashes = 1; line[n_hashes] == '#'; n_hashes++)
-			;
 		/* Copy line without the '#' and ' ' immediately after it. */
-		strncpy(ret, line + n_hashes + 1, (TITLE_SIZE + 1));
+		strncpy(ret, strrchr(line, '#') + 1, (TITLE_SIZE + 1));
 		ret[TITLE_SIZE] = '\0';	/* Ensure termination */
 
 		rewind(in);	/* Leave H1 in place for rendering */

--- a/swege.c
+++ b/swege.c
@@ -298,6 +298,7 @@ char *
 get_title(FILE * in)
 {
 	char *line = NULL;
+	int n_hashes;
 	size_t linecap = 0;
 	getline(&line, &linecap, in);
 
@@ -321,8 +322,11 @@ get_title(FILE * in)
 			}
 		}
 	} else if (strlen(line) >= 3 && line[0] == '#') {
+		/* Count the amount of '#' characters. */
+		for (n_hashes = 1; line[n_hashes] == '#'; n_hashes++)
+			;
 		/* Copy line without the '#' and ' ' immediately after it. */
-		strncpy(ret, strrchr(line, '#') + 1, (TITLE_SIZE + 1));
+		strncpy(ret, line + n_hashes + 1, (TITLE_SIZE + 1));
 		ret[TITLE_SIZE] = '\0';	/* Ensure termination */
 
 		rewind(in);	/* Leave H1 in place for rendering */

--- a/swege.c
+++ b/swege.c
@@ -298,6 +298,7 @@ char *
 get_title(FILE * in)
 {
 	char *line = NULL;
+	int n_hashes;
 	size_t linecap = 0;
 	getline(&line, &linecap, in);
 
@@ -321,8 +322,11 @@ get_title(FILE * in)
 			}
 		}
 	} else if (strlen(line) >= 3 && line[0] == '#') {
-		/* Copy line without the # */
-		strncpy(ret, line + 2, (TITLE_SIZE + 1));
+		/* Count the amount of '#' characters. */
+		for (n_hashes = 1; line[n_hashes] == '#'; n_hashes++)
+			;
+		/* Copy line without the '#' and ' ' immediately after it. */
+		strncpy(ret, line + n_hashes + 1, (TITLE_SIZE + 1));
 		ret[TITLE_SIZE] = '\0';	/* Ensure termination */
 
 		rewind(in);	/* Leave H1 in place for rendering */


### PR DESCRIPTION
If `# Title` is the first line of a Markdown file, then `swege` sets `<title>Title</title>` as the page title.
If `### Title` is used, then `swege` sets `<title># Title</title>` as the page title.

This pull request fixes that issue.